### PR TITLE
Don't manage API token for jenkins::api_user

### DIFF
--- a/manifests/api_user.pp
+++ b/manifests/api_user.pp
@@ -1,17 +1,15 @@
 # == Define: jenkins::api_user
 #
-# Create an account within Jenkins and set it's API token to a pre-hashed
-# value. Unfortunately the Jenkins API doesn't expose the ability to
-# create/modify users, so this is a bit of a hack. The configurations are
-# owned by root:root to prevent them from being modified in the Jenkins UI.
+# Create an account within Jenkins that will subsequently be used for API
+# access. No API token will be set as it needs to be hashed against a seed
+# that it specific to that installation of Jenkins. You will need to
+# subsequently generate a token through the Jenkins UI. The contents of the
+# user config file will not be managed after initial creation to prevent
+# conflicts with the Jenkins UI.
 # 
-# The name of the instance ($title) is used as the name of the account 
-# created. 
+# The name of the instance ($title) is used as the account name.
 #
 # === Parameters
-#
-# [*token_hash*]
-#   Hashed token that will be written to the user's `config.xml`.
 #
 # [*ensure*]
 #   Standard ensure param. Can be used to remove an existing user.
@@ -23,7 +21,6 @@
 #   Default: /var/lib/jenkins/users
 #
 define jenkins::api_user(
-  $token_hash,
   $ensure = present,
   $users_dir = '/var/lib/jenkins/users'
 ) {
@@ -33,9 +30,8 @@ define jenkins::api_user(
   }
 
   File {
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
+    owner  => 'jenkins',
+    mode   => '0640',
     notify => Class['jenkins::service'],
   }
 
@@ -49,5 +45,6 @@ define jenkins::api_user(
   file { "${users_dir}/${title}/config.xml":
     ensure  => $ensure,
     content => template('jenkins/api_user.xml.erb'),
+    replace => false,
   }
 }

--- a/spec/defines/jenkins_api_user_spec.rb
+++ b/spec/defines/jenkins_api_user_spec.rb
@@ -3,23 +3,14 @@ require 'spec_helper'
 describe 'jenkins::api_user' do
   let(:title) { 'slave' }
 
-  describe 'required params not passed' do
-    let(:params) {{ }}
-
-    it { expect { should }.to raise_error(Puppet::Error, /^Must pass token_hash /) }
-  end
-
   describe 'default params' do
-    let(:params) {{
-      :token_hash => 'mekmitasdigoat',
-    }}
+    let(:params) {{ }}
 
     it 'should contain parent directory with correct props' do
       should contain_file('/var/lib/jenkins/users/slave').with(
         :ensure => 'directory',
-        :owner  => 'root',
-        :group  => 'root',
-        :mode   => '0644',
+        :owner  => 'jenkins',
+        :mode   => '0640',
         :notify => 'Class[Jenkins::Service]'
       )
     end
@@ -27,11 +18,10 @@ describe 'jenkins::api_user' do
     it 'should contain config file with correct props' do
       should contain_file('/var/lib/jenkins/users/slave/config.xml').with(
         :ensure  => 'present',
-        :owner   => 'root',
-        :group   => 'root',
-        :mode    => '0644',
-        :notify  => 'Class[Jenkins::Service]',
-        :content => /^\s+<apiToken>mekmitasdigoat<\/apiToken>$/
+        :owner   => 'jenkins',
+        :mode    => '0640',
+        :replace => 'false',
+        :notify  => 'Class[Jenkins::Service]'
       )
     end
 
@@ -40,18 +30,11 @@ describe 'jenkins::api_user' do
         /^\s+<fullName>api_user: slave<\/fullName>$/
       )
     end
-
-    it 'should set apiToken in config file' do
-      should contain_file('/var/lib/jenkins/users/slave/config.xml').with_content(
-        /^\s+<apiToken>mekmitasdigoat<\/apiToken>$/
-      )
-    end
   end
 
   describe 'ensure absent' do
     let(:params) {{
-      :ensure     => 'absent',
-      :token_hash => 'mekmitasdigoat',
+      :ensure => 'absent',
     }}
 
     it { should contain_file('/var/lib/jenkins/users/slave').with_ensure('absent') }
@@ -60,8 +43,7 @@ describe 'jenkins::api_user' do
 
   describe 'custom state directory' do
     let(:params) {{
-      :token_hash => 'mekmitasdigoat',
-      :users_dir  => '/opt/jenkins/users',
+      :users_dir => '/opt/jenkins/users',
     }}
 
     it { should contain_file('/opt/jenkins/users/slave') }

--- a/templates/api_user.xml.erb
+++ b/templates/api_user.xml.erb
@@ -1,13 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <user>
   <fullName>api_user: <%= @title -%></fullName>
-  <description>WARNING!&#xd;
-&#xd;
-This user has been created and assigned an API token by Puppet.&#xd;
-You will not be able to make any changes through the Jenkins UI due to file permissions.</description>
+  <description>This local user has been created, but not subsequently managed, by Puppet.&#xd;
+Before first use you will need to generate an API token below.&#xd;
+That API token should then be distributed to any clients.</description>
   <properties>
     <jenkins.security.ApiTokenProperty>
-      <apiToken><%= @token_hash -%></apiToken>
+      <apiToken>REGENERATE_THIS_USING_THE_JENKINS_UI</apiToken>
     </jenkins.security.ApiTokenProperty>
     <com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty plugin="credentials@1.3.1">
       <credentials/>


### PR DESCRIPTION
So it turns out that the API token is hashed against both the username
(which is fine) and a seed that is specific to that installation of Jenkins
(not so fine). Meaning that the hash of an API token will invalidated
whenever a Jenkins master node is rebuilt. As such, it makes no sense for us
to set this. We should just create the user and then fetch the current token
from the Jenkins UI.

The file is now owned by `jenkins` and not replaced if it already exists.

/cc @danielabel 
