### PR TITLE
Ensuring that we have a jenkins 'users' dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,13 @@
 class jenkins::config(
   $config_hash = {},
 ) {
+
+  file { '/var/lib/jenkins/users':
+    ensure => 'directory',
+    owner  => 'jenkins',
+    mode   => '0755',
+  }
+
   Class['Jenkins::Package']->Class['Jenkins::Config']
   create_resources( 'jenkins::sysconfig', $config_hash )
 }


### PR DESCRIPTION
On clean installed puppet fails due to non-existance of the jenkins
users directory, this ensures that its there before we do other
operatons
