### PR TITLE
anchor init such that require => Class['::jenkins'] ensures package is installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,7 @@ class jenkins(
   $plugin_hash = undef,
 ) {
 
-  anchor { 'jenkins::start':}
+  anchor { 'jenkins::begin':}
   class {
     'jenkins::repo':
       lts  => $lts,
@@ -80,7 +80,7 @@ class jenkins(
   include jenkins::service
   include jenkins::firewall
 
-  Anchor['jenkins::start'] ->
+  Anchor['jenkins::begin'] ->
     Class['jenkins::repo'] ->
     Class['jenkins::package'] ->
     Class['jenkins::service'] ->


### PR DESCRIPTION
We would like to require => Class['::jenkins'] with the confidence that Package['::jenkins:package'] will be installed deterministically.
