### PR TITLE
Update Swarm-Client URL

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -20,7 +20,7 @@ class jenkins::slave (
 ) {
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
-  $client_url = "http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/${version}/"
+  $client_url = "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}"
 
   #add jenkins slave if necessary.
 

--- a/templates/jenkins-slave.erb
+++ b/templates/jenkins-slave.erb
@@ -4,10 +4,10 @@ stop on runlevel [!2345]
 script
         test -f /etc/default/locale && . /etc/default/locale || true
         export LANG
-        exec start-stop-daemon --start -c <%= slave_user -%> --exec /usr/bin/java \
-                --name jenkins-slave --  -jar <%= slave_home -%>/<%= client_jar -%> \
-                <%= ui_user_flag -%> <%= ui_pass_flag -%> \
-                -name <%= fqdn -%> -executors <%= executors -%> \
-                -autoDiscoveryAddress <%= broadcast_address -%> \
-                -fsroot <%= slave_home -%> -labels <%= labels %>
+        exec start-stop-daemon --start -c <%= @slave_user -%> --exec /usr/bin/java \
+                --name jenkins-slave --  -jar <%= @slave_home -%>/<%= @client_jar -%> \
+                <%= @ui_user_flag -%> <%= @ui_pass_flag -%> \
+                -name <%= @fqdn -%> -executors <%= @executors -%> \
+                -autoDiscoveryAddress <%= @broadcast_address -%> \
+                -fsroot <%= @slave_home -%> -labels <%= @labels %>
 end script


### PR DESCRIPTION
The URL for the swarm-client jar has changed. This means that Puppet was unable to download this jar.

Addition:

Not pertinent but have modified deprecated embedded ruby tags. Note this change does fix anything but
satisfies warnings from puppet.

This relates to https://github.com/alphagov/ci-puppet/pull/430